### PR TITLE
fix(blf): payload generate:types was failing with enabled plugin

### DIFF
--- a/packages/better-localized-fields/src/providers/LocalesData/provider.tsx
+++ b/packages/better-localized-fields/src/providers/LocalesData/provider.tsx
@@ -4,7 +4,6 @@ import './index.scss';
 
 import { getTranslation } from '@payloadcms/translations';
 import type { Row } from '@payloadcms/ui/fields/Row';
-import { RowProvider } from '@payloadcms/ui/fields/Row';
 import { useFieldProps } from '@payloadcms/ui/forms/FieldPropsProvider';
 import { RenderFields } from '@payloadcms/ui/forms/RenderFields';
 import { useConfig } from '@payloadcms/ui/providers/Config';
@@ -87,18 +86,16 @@ export const LocalesDataProvider = (props: React.ComponentProps<typeof Row>) => 
 
   return (
     <LocalesDataContext.Provider value={{ localesFormState: localesFormState ?? [] }}>
-      <RowProvider>
-        <div className='locales-data-provider'>
-          <RenderFields
-            {...{ fieldMap, forceRender, path, readOnly, schemaPath }}
-            fieldMap={fieldMap}
-            forceRender={forceRender}
-            indexPath={indexPath}
-            margins={false}
-            permissions={siblingPermissions}
-          />
-        </div>
-      </RowProvider>
+      <div className='locales-data-provider'>
+        <RenderFields
+          {...{ fieldMap, forceRender, path, readOnly, schemaPath }}
+          fieldMap={fieldMap}
+          forceRender={forceRender}
+          indexPath={indexPath}
+          margins={false}
+          permissions={siblingPermissions}
+        />
+      </div>
     </LocalesDataContext.Provider>
   );
 };

--- a/test/payload-types.ts
+++ b/test/payload-types.ts
@@ -12,6 +12,7 @@ export interface Config {
     posts: Post;
     'small-posts': SmallPost;
     'docs-reoder-examples': DocsReoderExample;
+    'better-localized-issue': BetterLocalizedIssue;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
@@ -102,6 +103,43 @@ export interface DocsReoderExample {
   id: string;
   title?: string | null;
   docOrder?: number | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "better-localized-issue".
+ */
+export interface BetterLocalizedIssue {
+  id: string;
+  text?: string | null;
+  named: {
+    text?: string | null;
+    inRow?: string | null;
+    inRow_second?: string | null;
+  };
+  localized: {
+    text?: string | null;
+  };
+  textCondition?: string | null;
+  blocks?:
+    | {
+        inRow?: string | null;
+        inRow_second?: string | null;
+        inRow_f?: string | null;
+        inRow_f_second?: string | null;
+        array?:
+          | {
+              text?: string | null;
+              id?: string | null;
+            }[]
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'some-block';
+      }[]
+    | null;
+  sidebar?: string | null;
   updatedAt: string;
   createdAt: string;
 }


### PR DESCRIPTION
For some reason, using `RowProvider` in custom component leads to:
```
ReferenceError: Cannot access 'row' before initialization
```

when using `payload generate:types`