### PR TITLE
Prevent null reference. Fixes #64

### DIFF
--- a/packages/translator/src/translate/traverseFields.ts
+++ b/packages/translator/src/translate/traverseFields.ts
@@ -206,6 +206,9 @@ export const traverseFields = ({
         const richTextDataFrom = siblingDataFrom[field.name] as object;
 
         siblingDataTranslated[field.name] = richTextDataFrom;
+        
+        if (!richTextDataFrom) break;
+        
         const isSlate = Array.isArray(richTextDataFrom);
 
         const isLexical = 'root' in richTextDataFrom;


### PR DESCRIPTION
If the `richTextDataFrom` value is `null` or `undefined` (which is a valid condition), the check for the `root` attr will fail.

This resolves the issue.