### PR TITLE
fix(translator): do not translate block IDs or admin-facing block labels

### DIFF
--- a/packages/translator/src/translate/traverseFields.ts
+++ b/packages/translator/src/translate/traverseFields.ts
@@ -192,6 +192,11 @@ export const traverseFields = ({
         if (!field.localized && !localizedParent && isEmpty(siblingDataFrom[field.name])) return;
         if (emptyOnly && siblingDataTranslated[field.name]) return;
 
+        // do not translate the block ID or admin-facing label
+        if (field.name === 'blockName' || field.name === 'id')  {
+          break;
+        }
+
         valuesToTranslate.push({
           onTranslate: (translated: string) => {
             siblingDataTranslated[field.name] = translated;


### PR DESCRIPTION
When debugging another issue I realized that the block IDs were getting sent along with the other translation data to the translation service. This seems undesirable.

Additionally, the admin block labels were also getting translated, which was making it difficult for our admins to make sense of the content as they primary only speak English.

This is the block label that I mean (the text that says `HERO IMAGE`):
<img width="650" alt="Screenshot 2024-06-12 at 6 39 06 PM" src="https://github.com/r1tsuu/payload-enchants/assets/468037/5058f5ce-7084-471d-83f4-3be2553d4c3f">

