### PR TITLE
fix(docs-order): resolve breaking change, set order field to be admin.hidden  

### DIFF
--- a/packages/docs-reorder/src/extendCollectionsConfig.ts
+++ b/packages/docs-reorder/src/extendCollectionsConfig.ts
@@ -11,7 +11,7 @@ const externdCollectionConfig = (collection: CollectionConfig) => {
       ...(collection.admin ?? {}),
       components: {
         ...(collection.admin?.components ?? {}),
-        BeforeList: [
+        beforeList: [
           ...(collection.admin?.components?.beforeList ?? []),
           CollectionDocsOrderButton,
         ],

--- a/packages/docs-reorder/src/extendCollectionsConfig.ts
+++ b/packages/docs-reorder/src/extendCollectionsConfig.ts
@@ -25,6 +25,9 @@ const externdCollectionConfig = (collection: CollectionConfig) => {
           read: () => true,
           update: () => false,
         },
+        admin: {
+          hidden: true,
+        },
         index: true,
         name: 'docOrder',
         type: 'number',


### PR DESCRIPTION
1) Payload [beta.56](https://github.com/payloadcms/payload/releases/tag/v3.0.0-beta.56) introduced a breaking change regarding casing of component hook properties
2) Sets order field to be hidden in admin UI