### PR TITLE
Skip translations for RichText

### DIFF
--- a/packages/translator/src/translate/traverseFields.ts
+++ b/packages/translator/src/translate/traverseFields.ts
@@ -210,6 +210,8 @@ export const traverseFields = ({
         break;
 
       case 'richText': {
+        if (field.custom && typeof field.custom === 'object' && field.custom.translatorSkip) break;
+        
         if (!(field.localized || localizedParent) || isEmpty(siblingDataFrom[field.name])) break;
         if (emptyOnly && siblingDataTranslated[field.name]) break;
 


### PR DESCRIPTION
# Situation
Currently, there is no way to stop receiving the texts from the `richText` field. This PR checks for `translatorSkip` property for the `richText` fields.
## Collection config
```
...
{
    name: 'content',
    type: 'richText',
    required: true,
    localized: true,
    custom: {
      translatorSkip: true,
    },
    editor: lexicalEditor(),
},
...
```

## Translator resolver
```
const myResolver: TranslateResolver = {
  key: 'translator-key',
  resolve: async ({localeTo, texts}) => {
    console.log("Args.texts", texts);
    const transformed = texts.map((each) => `${each} - ${localeTo}`);
    return {
      success: true,
      translatedTexts: transformed,
    };
  },
};
```

## How it looks in CMS UI
For english locale
<img width="2132" alt="image" src="https://github.com/user-attachments/assets/a256a31c-dd3f-4165-a1f0-de4e8511c7ec" />

## What the logs show
```
Args.texts [
  'RichText translatorSkip',
  'Summary',
  'Any content not to be translated'
]
```


With this PR rich texts will also be skipped