### PR TITLE
Enable selecting other language in modal popup

### DIFF
--- a/packages/translator/src/client/providers/Translator/TranslatorProvider.tsx
+++ b/packages/translator/src/client/providers/Translator/TranslatorProvider.tsx
@@ -85,11 +85,8 @@ export const TranslatorProvider = ({ children }: { children: ReactNode }) => {
       (each) => localization.defaultLocale === each.code,
     );
 
-    if (defaultFromOptions) {
-      setLocaleToTranslateFrom(defaultFromOptions.code);
-    } else {
-      setLocaleToTranslateFrom(localesOptions[0].code);
-    }
+    if (defaultFromOptions) setLocaleToTranslateFrom(defaultFromOptions.code);
+    setLocaleToTranslateFrom(localesOptions[0].code);
   }, [locale, localesOptions, localization.defaultLocale]);
 
   const closeTranslator = () => modal.closeModal(modalSlug);

--- a/packages/translator/src/client/providers/Translator/TranslatorProvider.tsx
+++ b/packages/translator/src/client/providers/Translator/TranslatorProvider.tsx
@@ -85,8 +85,11 @@ export const TranslatorProvider = ({ children }: { children: ReactNode }) => {
       (each) => localization.defaultLocale === each.code,
     );
 
-    if (defaultFromOptions) setLocaleToTranslateFrom(defaultFromOptions.code);
-    setLocaleToTranslateFrom(localesOptions[0].code);
+    if (defaultFromOptions) {
+      setLocaleToTranslateFrom(defaultFromOptions.code);
+    } else {
+      setLocaleToTranslateFrom(localesOptions[0].code);
+    }
   }, [locale, localesOptions, localization.defaultLocale]);
 
   const closeTranslator = () => modal.closeModal(modalSlug);

--- a/packages/translator/src/client/providers/Translator/TranslatorProvider.tsx
+++ b/packages/translator/src/client/providers/Translator/TranslatorProvider.tsx
@@ -87,7 +87,7 @@ export const TranslatorProvider = ({ children }: { children: ReactNode }) => {
 
     if (defaultFromOptions) setLocaleToTranslateFrom(defaultFromOptions.code);
     setLocaleToTranslateFrom(localesOptions[0].code);
-  }, [locale, localesOptions, localization.defaultLocale]);
+  }, [locale, localization.locales, localization.defaultLocale]);
 
   const closeTranslator = () => modal.closeModal(modalSlug);
 


### PR DESCRIPTION
Fixes #104

## Summary

User can't select other language options in modal popup.

## Root cause

Inside TranslatorProvider there is [setLocaleToTranslateFrom](https://github.com/r1tsuu/payload-enchants/blob/master/packages/translator/src/client/providers/Translator/TranslatorProvider.tsx#L81). Calling that function (state setter) will cause TranslatorProvider to re-render.

Every time TranslatorProvider re-renders the [localeOptions array](https://github.com/r1tsuu/payload-enchants/blob/master/packages/translator/src/client/providers/Translator/TranslatorProvider.tsx#L79) changes reference. 

useEffect has that [localeOptions in deps](https://github.com/r1tsuu/payload-enchants/blob/master/packages/translator/src/client/providers/Translator/TranslatorProvider.tsx#L90), which means that useEffect callback will be ran every time `localeOptions` changes reference i.e. every time TranslatorProvider re-renders.

[Here](https://github.com/r1tsuu/payload-enchants/blob/master/packages/translator/src/client/components/TranslatorModal/Content.tsx#L39) in Content component, we can see that every time we click on one option from the dropdown `setLocaleToTranslateFrom` is called and therefore TranslatorProvider is re-rendered -> `localeOptions` changes reference -> useEffect callback is called.

Problem with useEffect callback is that it resets chosen locale to [either defaultOption](https://github.com/r1tsuu/payload-enchants/blob/master/packages/translator/src/client/providers/Translator/TranslatorProvider.tsx#L88) or to [first locale in array](https://github.com/r1tsuu/payload-enchants/blob/master/packages/translator/src/client/providers/Translator/TranslatorProvider.tsx#L89).

**In conclusion**, every time we click on some option in the dropdown, the useEffect callback resets it to default locale or to first locale in  `localeOptions` array.


## Solution

Change deps of useEffect. useEffect callback can not be called every time we choose something from the dropdown. Instead of having `localeOptions` in deps, use `localization.locales`. 

That way, even when TranslatorProvider re-renders, the deps (localization.locales) will not change reference and `localeToTranslateFrom` will **not** be reset. In addition, if locales change in payload config, useEffect callback will apply necessary changes.