### PR TITLE
fix(sdk): PATCH method for update (#118)

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -189,7 +189,7 @@ export class PayloadApiClient<C extends Config> {
       headers: {
         'Content-Type': 'application/json',
       },
-      method: 'DELETE',
+      method: 'PATCH',
     });
 
     return response.json();


### PR DESCRIPTION
# Summary

For REST APIs, update actions should use  HTTP method `PATCH` instead of `DELETE`. 

# Root cause

Most likely missed from copy paste

# Solution

Change method

